### PR TITLE
Clear db prior to seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The app can be set up and run via the command line:
 
 | What | How |
 |-|-|
-| set up (install and db migrations) | `npm i`
+| set up (install and db migrations) (inc clear old db) | `npm i`
 | run api and dev server | `npm start` |
 | run unit tests | `npm t` |
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "api": "node api",
     "build": "webpack --mode production",
-    "db:create": "npm run db:migrate && npm run db:seed",
+    "db:create": "npm run db:migrate && npm run db:drop && npm run db:seed",
+    "db:drop": "node_modules/.bin/sequelize db:seed:undo:all",
     "db:migrate": "node_modules/.bin/sequelize db:migrate",
     "db:seed": "node_modules/.bin/sequelize db:seed:all",
     "postinstall": "npm run db:create",


### PR DESCRIPTION
Adding an additional step the the :create script which empties the db prior to seeding.

It appears sqlite does not impliment a `drop` but I have called the new function this as I believe it makes the intention of the action clear. Happy to change this of course.